### PR TITLE
Improve: propagate only xoa warnings

### DIFF
--- a/xoa_driver/__init__.py
+++ b/xoa_driver/__init__.py
@@ -1,6 +1,2 @@
 __version__ = "1.3.0b4"
 __short_version__ = "1.3"
-
-import warnings
-warnings.simplefilter('always', DeprecationWarning)
-warnings.formatwarning = lambda message, category, filename, lineno, *_: f"\n\33[101m{category.__name__}\33[0m: {message}\n\n"

--- a/xoa_driver/internals/core/commands/m_commands.py
+++ b/xoa_driver/internals/core/commands/m_commands.py
@@ -14,7 +14,8 @@ from ..protocol.fields import data_types as xt
 from ..protocol.fields.field import XmpField
 from ..registry import register_command
 from .enums import *  # noqa: F403
-import warnings
+from xoa_driver.internals import warn
+
 
 @register_command
 @dataclass
@@ -167,6 +168,7 @@ class M_VERSIONNO:
 
     _connection: "interfaces.IConnection"
     _module: int
+
     @dataclass(frozen=True)
     class GetDataAttr:
         version: XmpField[xt.XmpInt] = XmpField(xt.XmpInt)  # integer, the hardware image version number.
@@ -421,8 +423,8 @@ class M_CFPCONFIG:
             - port speed, in Gbps
         :rtype: M_CFPCONFIG.GetDataAttr
         """
-        
-        warnings.warn("module.cfp.config.get() (M_CFPCONFIG) is deprecated. Please use module.cfp.config_extended.get() (M_CFPCONFIGEXT) instead.", DeprecationWarning)
+
+        warn.depricated("module.cfp.config.get() (M_CFPCONFIG) is deprecated. Please use module.cfp.config_extended.get() (M_CFPCONFIGEXT) instead.")
 
         return Token(self._connection, build_get_request(self, module=self._module))
 
@@ -435,8 +437,8 @@ class M_CFPCONFIG:
         :type port_speed: int
         """
 
-        warnings.warn("module.cfp.config.set() (M_CFPCONFIG) is deprecated. Please use module.cfp.config_extended.set() (M_CFPCONFIGEXT) instead.", DeprecationWarning)
-        
+        warn.depricated("module.cfp.config.set() (M_CFPCONFIG) is deprecated. Please use module.cfp.config_extended.set() (M_CFPCONFIGEXT) instead.")
+
         return Token(self._connection, build_set_request(self, module=self._module, port_count=port_count, port_speed=port_speed))
 
 
@@ -1436,17 +1438,23 @@ class M_CLOCKPPBSWEEP:
     @dataclass(frozen=True)
     class SetDataAttr:
         mode: XmpField[xt.XmpInt] = XmpField(xt.XmpInt, choices=PPMSweepMode)  # coded byte, specifying the sweeping function: OFF or TRIANGLE
-        ppb_step: XmpField[xt.XmpInt] = XmpField(xt.XmpInt)  # integer >=0, the numeric clock adjustment in ppb per step of the sweep. If set to 0, the sweep will use as small steps as possible, creating a "linear" sweep of the clock rate.
-        step_delay: XmpField[xt.XmpInt] = XmpField(xt.XmpInt)  # integer >0 the delay in µs between each step in the sweep. If ppb_step is 0: The total time in µs to sweep linearly from 0 to max_ppb.
-        max_ppb: XmpField[xt.XmpInt] = XmpField(xt.XmpInt)  # integer != 0, the numeric maximum clock adjustment. The sign of max_ppb determines if the sweep will start with positive or negative offsets. When the next step would exceed the limit set by max_ppb, the sweep changes direction. I.e. the deviation will sweep from 0 to max_ppb, to (-max_ppb), and back to 0.
+        # integer >=0, the numeric clock adjustment in ppb per step of the sweep. If set to 0, the sweep will use as small steps as possible, creating a "linear" sweep of the clock rate.
+        ppb_step: XmpField[xt.XmpInt] = XmpField(xt.XmpInt)
+        # integer >0 the delay in µs between each step in the sweep. If ppb_step is 0: The total time in µs to sweep linearly from 0 to max_ppb.
+        step_delay: XmpField[xt.XmpInt] = XmpField(xt.XmpInt)
+        # integer != 0, the numeric maximum clock adjustment. The sign of max_ppb determines if the sweep will start with positive or negative offsets. When the next step would exceed the limit set by max_ppb, the sweep changes direction. I.e. the deviation will sweep from 0 to max_ppb, to (-max_ppb), and back to 0.
+        max_ppb: XmpField[xt.XmpInt] = XmpField(xt.XmpInt)
         loops: XmpField[xt.XmpInt] = XmpField(xt.XmpInt)  # integer >=0, the number of full sweeps performed. 0 means "indefinitely".
 
     @dataclass(frozen=True)
     class GetDataAttr:
         mode: XmpField[xt.XmpInt] = XmpField(xt.XmpInt, choices=PPMSweepMode)  # coded byte, specifying the sweeping function.
-        ppb_step: XmpField[xt.XmpInt] = XmpField(xt.XmpInt)  # integer >=0, the numeric clock adjustment in ppb per step of the sweep. If set to 0, the sweep will use as small steps as possible, creating a "linear" sweep of the clock rate.
-        step_delay: XmpField[xt.XmpInt] = XmpField(xt.XmpInt)  # integer >0 the delay in µs between each step in the sweep. If ppb_step is 0: The total time in µs to sweep linearly from 0 to max_ppb.
-        max_ppb: XmpField[xt.XmpInt] = XmpField(xt.XmpInt)  # integer != 0, the numeric maximum clock adjustment. The sign of max_ppb determines if the sweep will start with positive or negative offsets. When the next step would exceed the limit set by max_ppb, the sweep changes direction. I.e. the deviation will sweep from 0 to max_ppb, to (-max_ppb), and back to 0.
+        # integer >=0, the numeric clock adjustment in ppb per step of the sweep. If set to 0, the sweep will use as small steps as possible, creating a "linear" sweep of the clock rate.
+        ppb_step: XmpField[xt.XmpInt] = XmpField(xt.XmpInt)
+        # integer >0 the delay in µs between each step in the sweep. If ppb_step is 0: The total time in µs to sweep linearly from 0 to max_ppb.
+        step_delay: XmpField[xt.XmpInt] = XmpField(xt.XmpInt)
+        # integer != 0, the numeric maximum clock adjustment. The sign of max_ppb determines if the sweep will start with positive or negative offsets. When the next step would exceed the limit set by max_ppb, the sweep changes direction. I.e. the deviation will sweep from 0 to max_ppb, to (-max_ppb), and back to 0.
+        max_ppb: XmpField[xt.XmpInt] = XmpField(xt.XmpInt)
         loops: XmpField[xt.XmpInt] = XmpField(xt.XmpInt)  # integer >=0, the number of full sweeps performed. 0 means "indefinitely".
 
     def get(self) -> "Token[GetDataAttr]":
@@ -1497,7 +1505,8 @@ class M_CLOCKSWEEPSTATUS:
         curr_sweep: XmpField[xt.XmpInt] = XmpField(xt.XmpInt)  # integer >=0, the current full sweep number, counting from 0.
         curr_step: XmpField[xt.XmpInt] = XmpField(xt.XmpInt)  # integer >=0 the current step number inside the sweep, counting from 0.
 
-        max_steps: XmpField[xt.XmpInt] = XmpField(xt.XmpInt)  # integer, >0, the total number of steps comprising a full sweep. For "linear" sweeps (ppb_step=0, see M_CLOCKPPBSWEEP) this number is determined by the chassis. In other cases, the number is implicitly given by the M_CLOCKPPBSWEEP parameters.
+        # integer, >0, the total number of steps comprising a full sweep. For "linear" sweeps (ppb_step=0, see M_CLOCKPPBSWEEP) this number is determined by the chassis. In other cases, the number is implicitly given by the M_CLOCKPPBSWEEP parameters.
+        max_steps: XmpField[xt.XmpInt] = XmpField(xt.XmpInt)
 
     def get(self) -> "Token[GetDataAttr]":
         """Get the current status of the :class:`M_CLOCKPPBSWEEP` function.

--- a/xoa_driver/internals/warn.py
+++ b/xoa_driver/internals/warn.py
@@ -1,0 +1,32 @@
+import warnings
+from functools import partial
+
+__all__ = (
+    "depricated",
+    "resource"
+)
+
+
+class XoaResourceWarning(ResourceWarning):
+    ...
+
+
+class XoaDeprecationWarning(DeprecationWarning):
+    ...
+
+
+warnings.simplefilter('always', XoaResourceWarning)
+warnings.simplefilter('always', XoaDeprecationWarning)
+
+
+def formatter(message, category, filename, lineno, *_) -> str:
+    if category is XoaDeprecationWarning:
+        return f"\n\33[101m{category.__name__}\33[0m: {message}\n\n"
+    return f"\n\33[103m{category.__name__}\33[0m: {message}\n\n"
+
+
+warnings.formatwarning = formatter
+
+
+depricated = partial(warnings.warn, category=XoaDeprecationWarning)
+resource = partial(warnings.warn, category=XoaResourceWarning)

--- a/xoa_driver/v2/__init__.py
+++ b/xoa_driver/v2/__init__.py
@@ -1,9 +1,11 @@
 import sys
-import warnings
-print(sys.modules.get("xoa_driver.internals.hli_v1"))
+
+
 if "xoa_driver.internals.hli_v1" in sys.modules:
     raise ImportError("\33[101mUsing xoa_driver and xoa_driver.v2 at the same time is not allowed.\33[0m")
-else:
-    warnings.simplefilter('always', ResourceWarning)
-    warnings.formatwarning = lambda message, category, filename, lineno, *_: f"\n\33[103m{category.__name__}\33[0m: {message}\n\n"
-    warnings.warn("xoa_driver.v2 is under development and it subject to changes without notice.", ResourceWarning)
+
+from xoa_driver.internals import warn
+
+warn.resource(
+    "xoa_driver.v2 is under development and it subject to changes without notice.",
+)


### PR DESCRIPTION
Now is only boa warnings will be expose to the user, if user would like to see also working messages from other libraries then need to enable warning propagation by special flag for python.