### PR TITLE
Chimera impairment HLIv2 cleanup

### DIFF
--- a/xoa_driver/internals/hli_v2/ports/port_l23/chimera/pe_distribution.py
+++ b/xoa_driver/internals/hli_v2/ports/port_l23/chimera/pe_distribution.py
@@ -24,23 +24,8 @@ from xoa_driver.internals.core.commands import (
 )
 
 
-class ImpairmentDistributionConfig:
+class ImpairmentDistribution:
     def __init__(self, conn: "itf.IConnection", module_id: int, port_id: int, flow_index: int, impairment_type_index: "ImpairmentTypeIndex") -> None:
-        self.enable = PED_ENABLE(conn, module_id, port_id, flow_index, impairment_type_index)
-        """Impairment distribution control.
-        Representation of PED_ENABLE
-        """
-
-        self.schedule = PED_SCHEDULE(conn, module_id, port_id, flow_index, impairment_type_index)
-        """Impairment scheduling configuration.
-        Representation of PED_SCHEDULE
-        """
-
-        self.one_shot_status = PED_ONESHOTSTATUS(conn, module_id, port_id, flow_index, impairment_type_index)
-        """One-shot status.
-        Representation of PED_ONESHOTSTATUS
-        """
-
         self.off = PED_OFF(conn, module_id, port_id, flow_index, impairment_type_index)
         """Impairments Distribution to OFF.
         Representation of PED_OFF
@@ -62,84 +47,6 @@ class ImpairmentDistributionConfig:
         """
 
         self.random_burst = PED_RANDOMBURST(conn, module_id, port_id, flow_index, impairment_type_index)
-        """Random Burst configuration.
-        Representation of PED_RANDOMBURST
-        """
-
-        self.ge = PED_GE(conn, module_id, port_id, flow_index, impairment_type_index)
-        """Gilbert-Elliot distribution configuration.
-        Representation of PED_GE
-        """
-
-        self.uniform = PED_UNI(conn, module_id, port_id, flow_index, impairment_type_index)
-        """Uniform distribution configuration.
-        Representation of PED_UNI
-        """
-
-        self.gaussian = PED_GAUSS(conn, module_id, port_id, flow_index, impairment_type_index)
-        """Gaussian distribution configuration.
-        Representation of PED_GAUSS
-        """
-
-        self.poisson = PED_POISSON(conn, module_id, port_id, flow_index, impairment_type_index)
-        """Poisson distribution configuration.
-        Representation of PED_POISSON
-        """
-
-        self.gamma = PED_GAMMA(conn, module_id, port_id, flow_index, impairment_type_index)
-        """Gamma distribution configuration.
-        Representation of PED_GAMMA
-        """
-
-        self.custom = PED_CUST(conn, module_id, port_id, flow_index, impairment_type_index)
-        """Associate a custom distribution to a flow and impairment type.
-        Representation of PED_CUST
-        """
-
-        self.constant_delay = PED_CONST(conn, module_id, port_id, flow_index, impairment_type_index)
-        """Constant Delay distribution configuration.
-        Representation of PED_CONST
-        """
-
-        self.accumulate_and_burst = PED_ACCBURST(conn, module_id, port_id, flow_index, impairment_type_index)
-        """Accumulate & Burst distribution configuration.
-        Representation of PED_ACCBURST
-        """
-
-        self.step = PED_STEP(conn, module_id, port_id, flow_index, impairment_type_index)
-        """Step distribution configuration.
-        Representation of PED_STEP
-        """
-
-        self.fixed_burst = PED_FIXEDBURST(conn, module_id, port_id, flow_index, impairment_type_index)
-        """Fixed Burst distribution configuration.
-        Representation of PED_FIXEDBURST
-        """
-
-
-class ImpairmentDistribution:
-    def __init__(self, conn: "itf.IConnection", module_id: int, port_id: int, flow_index: int, impairment_type_index: "ImpairmentTypeIndex") -> None:
-        self.off = PED_OFF(conn, module_id, port_id, flow_index, impairment_type_index)
-        """Impairments Distribution to OFF.
-        Representation of PED_OFF
-        """
-
-        self.fixed = PED_FIXED(conn, module_id, port_id, flow_index, impairment_type_index)
-        """Fixed Rate distribution configuration.
-        Representation of PED_FIXED
-        """
-
-        self.random = PED_RANDOM(conn, module_id, port_id, flow_index, impairment_type_index)
-        """Random Rate distribution configuration.
-        Representation of PED_RANDOM
-        """
-
-        self.bit_error_rate = PED_BER(conn, module_id, port_id, flow_index, impairment_type_index)
-        """Bit Error Rate distribution configuration.
-        Representation of PED_BER
-        """
-
-        self.random = PED_RANDOMBURST(conn, module_id, port_id, flow_index, impairment_type_index)
         """Random Burst configuration.
         Representation of PED_RANDOMBURST
         """

--- a/xoa_driver/internals/hli_v2/ports/port_l23/chimera/port_emulation.py
+++ b/xoa_driver/internals/hli_v2/ports/port_l23/chimera/port_emulation.py
@@ -6,7 +6,6 @@ from dataclasses import astuple
 from xoa_driver.internals.core.commands.enums import ImpairmentTypeIndex
 from xoa_driver.internals.core.commands.ped_commands import PED_ENABLE, PED_ONESHOTSTATUS, PED_SCHEDULE
 
-from xoa_driver.internals.hli_v2.ports.port_l23.chimera.pe_distribution import ImpairmentDistributionConfig
 if TYPE_CHECKING:
     from xoa_driver.internals.core import interfaces as itf
 
@@ -279,7 +278,7 @@ class CCorruptionImpairment:
         Representation of PE_BANDPOLICER
         """
 
-        self.distribution = ImpairmentDistributionConfig(conn, module_id, port_id, flow_index, ImpairmentTypeIndex.CORRUPTION)
+        self.distribution = ImpairmentDistribution(conn, module_id, port_id, flow_index, ImpairmentTypeIndex.CORRUPTION)
 
         self.schedule = PED_SCHEDULE(conn, module_id, port_id, flow_index, ImpairmentTypeIndex.CORRUPTION)
         """Impairment scheduling configuration.
@@ -378,11 +377,6 @@ class CShaperImpairment:
         Representation of PE_BANDSHAPER
         """
 
-        self.enable = PED_ENABLE(conn, module_id, port_id, flow_index, ImpairmentTypeIndex.DROP)
-        """Impairment distribution control.
-        Representation of PED_ENABLE
-        """
-
 
 class CPolicerImpairment:
     """Bandwidth policer impairment configuration."""
@@ -391,11 +385,6 @@ class CPolicerImpairment:
         self.config = PE_BANDPOLICER(conn, module_id, port_id, flow_index)
         """Bandwidth policer configuration.
         Representation of PE_BANDPOLICER
-        """
-
-        self.enable = PED_ENABLE(conn, module_id, port_id, flow_index, ImpairmentTypeIndex.DROP)
-        """Impairment distribution control.
-        Representation of PED_ENABLE
         """
 
 


### PR DESCRIPTION
- remove PED_ENABLE from HLI of PE_BANDPOLICER and PE_BANDSHAPER which it is not support.
- remove leftover HLIv1.