### PR TITLE
Fix link training modulation enum

### DIFF
--- a/xoa_driver/internals/core/commands/enums.py
+++ b/xoa_driver/internals/core/commands/enums.py
@@ -2225,10 +2225,10 @@ class LinkTrainEncoding(IntEnum):
     NRZ = 0
     """NRZ (PAM2)"""
 
-    PAM4 = 1
+    PAM4 = 2
     """PAM4"""
 
-    PAM4_WITH_PRECODING = 2
+    PAM4_WITH_PRECODING = 3
     """PAM4 with precoding"""
 
     UNKNOWN = 255


### PR DESCRIPTION
The enum value 1 is not used. Pam4 is=2 and PAM4PRE=3