### PR TITLE
Use DEFAULT_FEC not NO_FEC

### DIFF
--- a/xoa_driver/functions/anlt.py
+++ b/xoa_driver/functions/anlt.py
@@ -54,8 +54,8 @@ class DoAnlt:
         return commands.PP_AUTONEG(*self._group).set(
             state,
             enums.AutoNegTecAbility.DEFAULT_TECH_MODE,
-            enums.AutoNegFECOption.NO_FEC,
-            enums.AutoNegFECOption.NO_FEC,
+            enums.AutoNegFECOption.DEFAULT_FEC,
+            enums.AutoNegFECOption.DEFAULT_FEC,
             enums.PauseMode.NO_PAUSE,
         )
 


### PR DESCRIPTION
NO_FEC is a hard choice whereas DEFAULT_FEC is dynamic to let Xenaserver choose what is default based on link techknology