### PR TITLE
Improve testing actions

### DIFF
--- a/.github/workflows/testing_auto.yml
+++ b/.github/workflows/testing_auto.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   call-regression-test:
     name: "Regression test"
-    uses: xenanetworks/xoa-regression-tests/.github/workflows/execute-test-suite-denmark-tester.yml@main
+    uses: xenanetworks/xoa-regression-tests/.github/workflows/execute-test-suite-denmark-tester.yml@fch-actions
     secrets: inherit
 
 concurrency:

--- a/.github/workflows/testing_auto.yml
+++ b/.github/workflows/testing_auto.yml
@@ -1,0 +1,22 @@
+name: Auto Testing
+run-name: 🐛 Compatibility of "${{ github.event.head_commit.message }}"
+
+on:
+  push:
+    branches:
+      - "**"
+    paths-ignore:
+      - 'docs/**'
+      - README.md
+      - .gitignore
+      - .github/**
+
+jobs:
+  call-regression-test:
+    name: "Regression test"
+    uses: xenanetworks/xoa-regression-tests/.github/workflows/execute-test-suite-denmark-tester.yml@main
+    secrets: inherit
+
+concurrency:
+  group: ${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true

--- a/.github/workflows/testing_manual.yml
+++ b/.github/workflows/testing_manual.yml
@@ -1,0 +1,42 @@
+name: Manual Testing
+run-name: 🐛 Compatibility of TS@${{inputs.test_suites_branch}}, core@${{inputs.core_branch}}, converter@${{inputs.converter_branch}} and driver@${{inputs.driver_branch}}
+
+on:
+  workflow_dispatch:
+    inputs:
+      test_suites_branch:
+          description: 'Test suites branch'
+          required: true
+          type: string
+          default: 'dev'
+      core_branch:
+          description: 'Core branch'
+          required: true
+          type: string
+          default: 'dev'
+      converter_branch:
+          description: 'Converter branch'
+          required: true
+          type: string
+          default: 'dev'
+      driver_branch:
+          description: 'Driver branch'
+          required: true
+          type: string
+          default: 'dev'
+
+jobs:
+  call-regression-test:
+    name: "Regression test"
+    uses: xenanetworks/xoa-regression-tests/.github/workflows/execute-test-suite-denmark-tester.yml@fch-actions
+    secrets: inherit
+    with:
+      test_suites_branch: ${{inputs.test_suites_branch}}
+      core_branch: ${{inputs.core_branch}}
+      converter_branch: ${{inputs.converter_branch}}
+      driver_branch: ${{inputs.driver_branch}}
+
+
+concurrency:
+  group: ${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true

--- a/.github/workflows/testing_manual.yml
+++ b/.github/workflows/testing_manual.yml
@@ -28,14 +28,8 @@ on:
 jobs:
   call-regression-test:
     name: "Regression test"
-    uses: xenanetworks/xoa-regression-tests/.github/workflows/execute-test-suite-denmark-tester.yml@fch-actions
+    uses: xenanetworks/xoa-regression-tests/.github/workflows/execute-test-suite-denmark-tester.yml@main
     secrets: inherit
-    with:
-      test_suites_branch: ${{inputs.test_suites_branch}}
-      core_branch: ${{inputs.core_branch}}
-      converter_branch: ${{inputs.converter_branch}}
-      driver_branch: ${{inputs.driver_branch}}
-
 
 concurrency:
   group: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/testing_manual.yml
+++ b/.github/workflows/testing_manual.yml
@@ -28,7 +28,7 @@ on:
 jobs:
   call-regression-test:
     name: "Regression test"
-    uses: xenanetworks/xoa-regression-tests/.github/workflows/execute-test-suite-denmark-tester.yml@main
+    uses: xenanetworks/xoa-regression-tests/.github/workflows/execute-test-suite-denmark-tester.yml@fch-actions
     secrets: inherit
 
 concurrency:


### PR DESCRIPTION
Add manual testing allow developer test on specific branch.
![1684916426566](https://github.com/xenanetworks/open-automation-python-api/assets/2508212/8bd04736-c8bb-48e9-8246-b51ebc67f58b)


show tested deps directly.
![1684916512296](https://github.com/xenanetworks/open-automation-python-api/assets/2508212/d81bdcbc-d9ba-4517-91a8-b7bf54d68f9e)

Auto test will only invoked by push event with fixed dev branch of {TS, core, converter, driver}.
Please merge this PR at the same time: https://github.com/xenanetworks/xoa-regression-tests/pull/2