### PR TITLE
Unify "serdes" param name

### DIFF
--- a/xoa_driver/__init__.py
+++ b/xoa_driver/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.1.1"
+__version__ = "2.1.2"
 __short_version__ = "2.0"

--- a/xoa_driver/internals/hli_v1/ports/port_l23/family_i.py
+++ b/xoa_driver/internals/hli_v1/ports/port_l23/family_i.py
@@ -50,7 +50,7 @@ class FamilyI(BasePortL23Genuine):
     :type: PcsPma
     """
     
-    ser_des: Tuple[SerDes, ...]
+    serdes: Tuple[SerDes, ...]
     """SerDes index
 
     :type: Tuple[SerDes, ...]

--- a/xoa_driver/internals/hli_v1/ports/port_l23/family_j.py
+++ b/xoa_driver/internals/hli_v1/ports/port_l23/family_j.py
@@ -33,7 +33,7 @@ class FamilyJ(BasePortL23Genuine):
     :type: PcsPma
     """
     
-    ser_des: Tuple[SerDes, ...]
+    serdes: Tuple[SerDes, ...]
     """SerDes index
 
     :type: Tuple[SerDes, ...]

--- a/xoa_driver/internals/hli_v1/ports/port_l23/family_k.py
+++ b/xoa_driver/internals/hli_v1/ports/port_l23/family_k.py
@@ -33,7 +33,7 @@ class FamilyK(BasePortL23Genuine):
     :type: PcsPma
     """
     
-    ser_des: Tuple[SerDes, ...]
+    serdes: Tuple[SerDes, ...]
     """SerDes index
 
     :type: Tuple[SerDes, ...]

--- a/xoa_driver/internals/hli_v1/ports/port_l23/family_l.py
+++ b/xoa_driver/internals/hli_v1/ports/port_l23/family_l.py
@@ -35,7 +35,7 @@ class FamilyL(BasePortL23Genuine):
     :type: PcsPma
     """
     
-    ser_des: Tuple[SerDes, ...]
+    serdes: Tuple[SerDes, ...]
     """SerDes index
 
     :type: Tuple[SerDes, ...]

--- a/xoa_driver/internals/hli_v1/ports/port_l23/family_l1.py
+++ b/xoa_driver/internals/hli_v1/ports/port_l23/family_l1.py
@@ -38,7 +38,7 @@ class FamilyL1(BasePortL23Genuine):
     :type: PcsPma
     """
     
-    ser_des: Tuple[SerDes, ...]
+    serdes: Tuple[SerDes, ...]
     """SerDes index
 
     :type: Tuple[SerDes, ...]
@@ -57,7 +57,7 @@ class FamilyL1(BasePortL23Genuine):
     async def _setup(self) -> Self:
         await super()._setup()
         self.pcs_pma = PcsPma(self._conn, self)
-        self.ser_des = tuple(
+        self.serdes = tuple(
             SerDes(self._conn, *self.kind, serdes_xindex=serdes_xindex)
             for serdes_xindex in range(self.info.capabilities.serdes_count)
         )

--- a/xoa_driver/internals/hli_v2/ports/port_l23/family_l1.py
+++ b/xoa_driver/internals/hli_v2/ports/port_l23/family_l1.py
@@ -31,7 +31,7 @@ class PcsPma(PcsPma1, PcsPma2, PcsPma3):
 
 class FamilyL1(BasePortL23Genuine):
     pcs_pma: PcsPma
-    ser_des: Tuple[SerDes, ...]
+    serdes: Tuple[SerDes, ...]
 
     def __init__(self, conn: "itf.IConnection", module_id: int, port_id: int) -> None:
         super().__init__(conn, module_id, port_id)
@@ -45,7 +45,7 @@ class FamilyL1(BasePortL23Genuine):
     async def _setup(self) -> Self:
         await super()._setup()
         self.pcs_pma = PcsPma(self._conn, self)
-        self.ser_des = tuple(
+        self.serdes = tuple(
             SerDes(self._conn, *self.kind, serdes_xindex=serdes_xindex)
             for serdes_xindex in range(self.info.capabilities.serdes_count)
         )


### PR DESCRIPTION
This is to unify the attribute name `serdes`.

Some ports use `ser_des` and some use `serdes`. This is to unify them to `serdes`