### PR TITLE
2.8.0

### DIFF
--- a/docs/source/api_ref/hlapiv1/module/identification.rst
+++ b/docs/source/api_ref/hlapiv1/module/identification.rst
@@ -110,3 +110,27 @@ Corresponding CLI command: ``M_STATUS``
     # Status
     resp = await module.status.get()
     resp.temperature
+
+Model Name
+------------
+Get the model name of the module.
+
+Corresponding CLI command: ``M_MODEL_NAME``
+
+.. code-block:: python
+
+    # Model Name
+    resp = await module.model_name.get()
+    resp.name
+
+Model Version String
+--------------------
+Returns the currently running module software version. Obsoletes ``M_VERSIONNO``.
+
+Corresponding CLI command: ``M_VERSIONSTR``
+
+.. code-block:: python
+
+    # Model Version String
+    resp = await module.version_str.get()
+    resp.version_str

--- a/docs/source/api_ref/hlapiv1/module/status.rst
+++ b/docs/source/api_ref/hlapiv1/module/status.rst
@@ -1,0 +1,15 @@
+Status
+=========================
+
+Health
+----------------
+Gets the module health information.
+
+Corresponding CLI command: ``M_HEALTH``
+
+.. code-block:: python
+
+    # Health
+    resp = await module.health.all.get()
+    resp = await module.health.info.get()
+    resp = await module.health.cage_insertion.get()

--- a/docs/source/api_ref/hlapiv1/port/general/control.rst
+++ b/docs/source/api_ref/hlapiv1/port/general/control.rst
@@ -156,6 +156,18 @@ Corresponding CLI command: ``P_BRRMODE``
     resp = await port.brr_mode.get()
     resp.mode
 
+BRR Status
+----------
+Get the actual BroadR-Reach status of the port.
+
+Corresponding CLI command: ``P_BRRSTATUS``
+
+.. code-block:: python
+
+    # BRR Status
+    resp = await port.brr_status.get()
+    resp.mode
+
 
 MDI/MDIX Mode
 -------------

--- a/docs/source/api_ref/hlapiv1/tester/identification.rst
+++ b/docs/source/api_ref/hlapiv1/tester/identification.rst
@@ -100,3 +100,39 @@ Corresponding CLI command: ``C_BUILDSTRING``
     # Build String
     resp = await tester.build_string.get()
     resp.build_string
+
+Version String
+-----------------
+Returns the currently running chassis software version. Obsoletes ``C_VERSIONNO`` and ``C_VERSIONNO_MINOR``
+
+Corresponding CLI command: ``C_VERSIONSTR``
+
+.. code-block:: python
+
+    # Firmware Version
+    resp = await tester.version_str.get()
+    resp.version_str
+
+Model Name
+-----------------
+Get the Xena chassis model name.
+
+Corresponding CLI command: ``C_MODEL_NAME``
+
+.. code-block:: python
+
+    # Model Name
+    resp = await tester.model_name.get()
+    resp.name
+
+Model Number
+-----------------
+Get the Xena chassis model number.
+
+Corresponding CLI command: ``C_MODEL_NUMBER``
+
+.. code-block:: python
+
+    # Model Name
+    resp = await tester.model_number.get()
+    resp.number

--- a/docs/source/api_ref/hlapiv1/tester/status.rst
+++ b/docs/source/api_ref/hlapiv1/tester/status.rst
@@ -1,0 +1,16 @@
+Status
+=========================
+
+Health
+----------------
+Gets the chassis system health information.
+
+Corresponding CLI command: ``C_HEALTH``
+
+.. code-block:: python
+
+    # Health
+    resp = await tester.health.all.get()
+    resp = await tester.health.info.get()
+    resp = await tester.health.uptime.get()
+    resp.info

--- a/docs/source/api_ref/hlfunc/mgmt/index.rst
+++ b/docs/source/api_ref/hlfunc/mgmt/index.rst
@@ -7,19 +7,14 @@ The following high-level functions handle test resource management, e.g. connect
 
 .. currentmodule:: xoa_driver.hlfuncs.mgmt
 
-HL Port Functions
--------------------------
+HL Tester Functions
+---------------------------
 
-.. autofunction:: reserve_port
+.. autofunction:: reserve_tester
 
-.. autofunction:: reset_port
+.. autofunction:: free_tester
 
-.. autofunction:: free_port
-
-.. autofunction:: get_port
-
-.. autofunction:: free_ports
-
+.. autofunction:: get_chassis_sys_uptime_sec
 
 HL Module Functions
 ---------------------------
@@ -29,6 +24,8 @@ HL Module Functions
 .. autofunction:: free_module
 
 .. autofunction:: get_module
+
+.. autofunction:: get_modules
 
 .. autofunction:: get_module_supported_media
 
@@ -40,16 +37,31 @@ HL Module Functions
 
 .. autofunction:: get_module_eol_days
 
+.. autofunction:: get_module_cage_insertion_count
+
+HL Port Functions
+-------------------------
+
+.. autofunction:: reserve_port
+
+.. autofunction:: reset_port
+
+.. autofunction:: free_port
+
+.. autofunction:: get_port
+
 .. autofunction:: get_ports
-
-
-HL Tester Functions
----------------------------
-
-.. autofunction:: reserve_tester
-
-.. autofunction:: free_tester
 
 .. autofunction:: get_all_ports
 
-.. autofunction:: get_modules
+.. autofunction:: free_ports
+
+HL Stream Functions
+-------------------------
+
+.. autofunction:: remove_streams
+
+
+
+
+

--- a/xoa_driver/__init__.py
+++ b/xoa_driver/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.7.1"
+__version__ = "2.7.2"
 __short_version__ = "2.7"

--- a/xoa_driver/__init__.py
+++ b/xoa_driver/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.7.0"
+__version__ = "2.7.1"
 __short_version__ = "2.7"

--- a/xoa_driver/__init__.py
+++ b/xoa_driver/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "2.7.2"
-__short_version__ = "2.7"
+__version__ = "2.8.0"
+__short_version__ = "2.8"

--- a/xoa_driver/functions/headers.py
+++ b/xoa_driver/functions/headers.py
@@ -11,6 +11,7 @@ from ipaddress import IPv4Address, IPv6Address
 from binascii import hexlify
 from xoa_driver.misc import Hex
 from enum import Enum
+from dataclasses import dataclass
 
 class EtherType(Enum):
     IPv4 = 0x0800
@@ -39,12 +40,11 @@ class ARPHardwareType(Enum):
 ####################################
 #           Ethernet               #
 ####################################
+@dataclass
 class Ethernet:
-
-    def __init__(self):
-        self.dst_mac: str = "0000.0000.0000"
-        self.src_mac: str = "0000.0000.0000"
-        self.ethertype: EtherType = EtherType.NONE
+    dst_mac: str = "0000.0000.0000"
+    src_mac: str = "0000.0000.0000"
+    ethertype: EtherType = EtherType.NONE
     
     def __str__(self):
         _dst_mac: str = self.dst_mac.replace(".", "")
@@ -55,12 +55,13 @@ class Ethernet:
 ####################################
 #           VLAN               #
 ####################################
+
+@dataclass
 class VLAN:
-    def __init__(self):
-        self.pri: int = 0
-        self.dei: int = 0
-        self.id: int = 0
-        self.type: EtherType = EtherType.NONE
+    pri: int = 0
+    dei: int = 0
+    id: int = 0
+    type: EtherType = EtherType.NONE
     
     def __str__(self):
         _pri_dei: str = '{:01X}'.format((self.pri<<1)+self.dei)
@@ -72,17 +73,17 @@ class VLAN:
 ####################################
 #           ARP                    #
 ####################################
+@dataclass
 class ARP:
-    def __init__(self):
-        self.hardware_type: ARPHardwareType = ARPHardwareType.Ethernet
-        self.protocol_type: EtherType = EtherType.IPv4
-        self.hardware_size: int = 6
-        self.protocol_size: int = 4
-        self.opcode: ARPOpcode = ARPOpcode.Request
-        self.sender_mac: str = "0000.0000.0000"
-        self.sender_ip: str = "0.0.0.0"
-        self.target_mac: str = "0000.0000.0000"
-        self.target_ip: str = "0.0.0.0"
+    hardware_type: ARPHardwareType = ARPHardwareType.Ethernet
+    protocol_type: EtherType = EtherType.IPv4
+    hardware_size: int = 6
+    protocol_size: int = 4
+    opcode: ARPOpcode = ARPOpcode.Request
+    sender_mac: str = "0000.0000.0000"
+    sender_ip: str = "0.0.0.0"
+    target_mac: str = "0000.0000.0000"
+    target_ip: str = "0.0.0.0"
     
     def __str__(self):
         _hardware_type: str = '{:04X}'.format(self.hardware_type.value)
@@ -99,21 +100,21 @@ class ARP:
 ####################################
 #           IPv4                   #
 ####################################
+@dataclass
 class IPV4:
-    def __init__(self):
-        self.version: int = 4
-        self.header_length: int = 5
-        self.dscp: int = 0
-        self.ecn: int = 0
-        self.total_length: int = 0
-        self.identification: str = "0000"
-        self.flags: int = 0
-        self.offset: int = 0
-        self.ttl: int = 255
-        self.proto: IPProtocol = IPProtocol.NONE
-        self.checksum: str = "0000"
-        self.src: str = "0.0.0.0"
-        self.dst: str = "0.0.0.0"
+    version: int = 4
+    header_length: int = 5
+    dscp: int = 0
+    ecn: int = 0
+    total_length: int = 0
+    identification: str = "0000"
+    flags: int = 0
+    offset: int = 0
+    ttl: int = 255
+    proto: IPProtocol = IPProtocol.NONE
+    checksum: str = "0000"
+    src: str = "0.0.0.0"
+    dst: str = "0.0.0.0"
 
     def __str__(self):
         _ver: str = '{:01X}'.format(self.version)
@@ -132,16 +133,16 @@ class IPV4:
 ####################################
 #           IPv6                   #
 ####################################
+@dataclass
 class IPV6:
-    def __init__(self):
-        self.version: int = 6
-        self.traff_class: int = 8
-        self.flow_label: int = 0
-        self.payload_length: int = 0
-        self.next_header: IPProtocol = IPProtocol.NONE
-        self.hop_limit: int = 1
-        self.src: str = "2000::2"
-        self.dst: str = "2000::100"
+    version: int = 6
+    traff_class: int = 8
+    flow_label: int = 0
+    payload_length: int = 0
+    next_header: IPProtocol = IPProtocol.NONE
+    hop_limit: int = 1
+    src: str = "2000::2"
+    dst: str = "2000::100"
 
     def __str__(self):
         _ver: str = '{:01X}'.format(self.version)
@@ -157,12 +158,12 @@ class IPV6:
 ####################################
 #           UDP                    #
 ####################################
+@dataclass
 class UDP:
-    def __init__(self):
-        self.src_port: int = 0
-        self.dst_port: int = 0
-        self.length: int = 8
-        self.checksum = "0000"
+    src_port: int = 0
+    dst_port: int = 0
+    length: int = 8
+    checksum = "0000"
 
     def __str__(self):
         _src_port: str = '{:04X}'.format(self.src_port)
@@ -174,37 +175,37 @@ class UDP:
 ####################################
 #           TCP                    #
 ####################################
+@dataclass
 class TCP:
-    def __init__(self):
-        self.src_port: int = 0
-        self.dst_port: int = 0
-        self.seq_num: int = 0
-        self.ack_num: int = 0
-        self.header_length: int = 20
-        """Aka. Data Offset (bytes)"""
-        self.rsrvd: int = 0
-        """Reserved 000"""
-        self.ae: int = 0
-        """Accurate ECN"""
-        self.cwr: int = 0
-        """Congestion Window Reduced"""
-        self.ece: int = 0
-        """ECN-Echo"""
-        self.urg: int = 0
-        """Urgent"""
-        self.ack: int = 0
-        """Acknowledgment"""
-        self.psh: int = 0
-        """Push"""
-        self.rst: int = 0
-        """Rest"""
-        self.syn: int = 0
-        """Sync"""
-        self.fin: int = 0
-        """Fin"""
-        self.window: int = 0
-        self.checksum: str = "0000"
-        self.urgent_pointer: int = 0
+    src_port: int = 0
+    dst_port: int = 0
+    seq_num: int = 0
+    ack_num: int = 0
+    header_length: int = 20
+    """Aka. Data Offset (bytes)"""
+    rsrvd: int = 0
+    """Reserved 000"""
+    ae: int = 0
+    """Accurate ECN"""
+    cwr: int = 0
+    """Congestion Window Reduced"""
+    ece: int = 0
+    """ECN-Echo"""
+    urg: int = 0
+    """Urgent"""
+    ack: int = 0
+    """Acknowledgment"""
+    psh: int = 0
+    """Push"""
+    rst: int = 0
+    """Rest"""
+    syn: int = 0
+    """Sync"""
+    fin: int = 0
+    """Fin"""
+    window: int = 0
+    checksum: str = "0000"
+    urgent_pointer: int = 0
 
     def __str__(self):
         _src_port: str = '{:04X}'.format(self.src_port)
@@ -235,42 +236,42 @@ class TCP:
 ####################################
 #           PTP                    #
 ####################################
+@dataclass
 class PTP:
-    def __init__(self):
-        self.version_ptp: int = 1
-        self.version_network: int = 1
-        self.subdomain: str = "5f44464c540000000000000000000000"
-        self.message_type: int = 1
-        self.source_comm_tech: int = 1
-        self.source_uuid: str = "0030051d1e27"
-        self.source_port_id: int = 1
-        self.seq_id: int = 94
-        self.control_field: int = 0
-        self.flags: str = "0008"
-        self.original_timestamp_sec: int = 1163594296
-        self.original_timestamp_nsec: int = 247015000
-        self.epoch_num: int = 0
-        self.current_utc_offset: int = 0
-        self.gm_comm_tech: int = 1
-        self.gm_clock_uuid: str = "0030051d1e27"
-        self.gm_port_id: int = 0
-        self.gm_seq_id: int = 94
-        self.gm_clock_stratum: int = 4
-        self.gm_clock_id: str = "44464c54"
-        self.gm_clock_variance: int = -4000
-        self.gm_preferred: int = 0
-        self.gm_is_boundary_clock: int = 0
-        self.sync_interval: int = 1
-        self.local_clock_variance: int = -4000
-        self.local_step_removed: int = 0
-        self.local_clock_stratum: int = 4
-        self.local_clock_id: str = "44464c54"
-        self.parent_comm_tech: int = 1
-        self.parent_clock_uuid: str = "0030051D1E27"
-        self.parent_port_id: int = 0
-        self.est_master_variance: int = 0
-        self.est_master_drift: int = 0
-        self.utc_reasonable: int = 1
+    version_ptp: int = 1
+    version_network: int = 1
+    subdomain: str = "5f44464c540000000000000000000000"
+    message_type: int = 1
+    source_comm_tech: int = 1
+    source_uuid: str = "0030051d1e27"
+    source_port_id: int = 1
+    seq_id: int = 94
+    control_field: int = 0
+    flags: str = "0008"
+    original_timestamp_sec: int = 1163594296
+    original_timestamp_nsec: int = 247015000
+    epoch_num: int = 0
+    current_utc_offset: int = 0
+    gm_comm_tech: int = 1
+    gm_clock_uuid: str = "0030051d1e27"
+    gm_port_id: int = 0
+    gm_seq_id: int = 94
+    gm_clock_stratum: int = 4
+    gm_clock_id: str = "44464c54"
+    gm_clock_variance: int = -4000
+    gm_preferred: int = 0
+    gm_is_boundary_clock: int = 0
+    sync_interval: int = 1
+    local_clock_variance: int = -4000
+    local_step_removed: int = 0
+    local_clock_stratum: int = 4
+    local_clock_id: str = "44464c54"
+    parent_comm_tech: int = 1
+    parent_clock_uuid: str = "0030051D1E27"
+    parent_port_id: int = 0
+    est_master_variance: int = 0
+    est_master_drift: int = 0
+    utc_reasonable: int = 1
 
     def __str__(self):
         _version_ptp: str = '{:04X}'.format(self.version_ptp)
@@ -313,15 +314,15 @@ class PTP:
 ####################################
 #  eCPRI GeneralDataTransfer       #
 ####################################
+@dataclass
 class eCPRIGeneralDataTransfer:
-    def __init__(self):
-        self.protocol_rev: int = 1
-        self.c_bit: int = 0
-        self.message_type: str = "03"
-        self.payload_size = 24
-        self.pc_id: str= "12345678"
-        self.seq_id: str = "87654321"
-        self.user_data: str = "0f0e0d0c0b0a09080706050403020100"
+    protocol_rev: int = 1
+    c_bit: int = 0
+    message_type: str = "03"
+    payload_size = 24
+    pc_id: str= "12345678"
+    seq_id: str = "87654321"
+    user_data: str = "0f0e0d0c0b0a09080706050403020100"
 
     def __str__(self):
         _tmp: str = '{:02X}'.format((self.protocol_rev<<4)+self.c_bit)

--- a/xoa_driver/internals/commands/c_commands.py
+++ b/xoa_driver/internals/commands/c_commands.py
@@ -751,7 +751,9 @@ class C_PASSWORD:
 @dataclass
 class C_VERSIONSTR:
     """
-    Returns xenaserver version number in the new format, e.g. "466.0.0-XHacked.mke+174.1"
+    Returns xenaserver version number in the new format, e.g. "467.0.0+1.0"
+
+    Obsoletes C_VERSIONNO and C_VERSIONNO_MINOR
     """
 
     code: typing.ClassVar[int] = 23
@@ -761,7 +763,7 @@ class C_VERSIONSTR:
 
     class GetDataAttr(ResponseBodyStruct):
         version_str: str = field(XmpStr())
-        """string, xenaserver version number in the new format, e.g. 466.0.0-XHacked.mke+174.1"""
+        """string, xenaserver version number in the new format."""
 
     def get(self) -> Token[GetDataAttr]:
         """Returns xenaserver version number in the new format.

--- a/xoa_driver/internals/commands/c_commands.py
+++ b/xoa_driver/internals/commands/c_commands.py
@@ -749,6 +749,32 @@ class C_PASSWORD:
 
 @register_command
 @dataclass
+class C_VERSIONSTR:
+    """
+    Returns xenaserver version number in the new format, e.g. "466.0.0-XHacked.mke+174.1"
+    """
+
+    code: typing.ClassVar[int] = 23
+    pushed: typing.ClassVar[bool] = False
+
+    _connection: 'interfaces.IConnection'
+
+    class GetDataAttr(ResponseBodyStruct):
+        version_str: str = field(XmpStr())
+        """string, xenaserver version number in the new format, e.g. 466.0.0-XHacked.mke+174.1"""
+
+    def get(self) -> Token[GetDataAttr]:
+        """Returns xenaserver version number in the new format.
+
+        :return: xenaserver version number in the new format
+        :rtype: C_VERSIONSTR.GetDataAttr
+        """
+
+        return Token(self._connection, build_get_request(self))
+
+
+@register_command
+@dataclass
 class C_IPADDRESS:
     """
     The network configuration parameters of the chassis management port.

--- a/xoa_driver/internals/commands/c_commands.py
+++ b/xoa_driver/internals/commands/c_commands.py
@@ -1332,6 +1332,34 @@ class C_STATSESSION:
 
 @register_command
 @dataclass
+class C_HEALTH:
+    """
+    Gets the chassis system health information.
+    """
+
+    code: typing.ClassVar[int] = 47
+    pushed: typing.ClassVar[bool] = False
+
+    _connection: 'interfaces.IConnection'
+
+    _sub_indices: typing.List[int]
+
+    class GetDataAttr(ResponseBodyStruct):
+        info: str = field(XmpStr())
+        """Chassis health information json string"""
+
+    def get(self) -> Token[GetDataAttr]:
+        """Gets the Chassis health information.
+
+        :return: Chassis health information json string
+        :rtype: C_HEALTH.GetDataAttr
+        """
+
+        return Token(self._connection, build_get_request(self, indices=self._sub_indices))
+
+
+@register_command
+@dataclass
 class C_TKLICFILE:
     """
     Get Xena TimeKeeper license file content.

--- a/xoa_driver/internals/commands/m_commands.py
+++ b/xoa_driver/internals/commands/m_commands.py
@@ -1833,6 +1833,7 @@ class M_HEALTH:
 
     _connection: 'interfaces.IConnection'
     _module: int
+    _sub_indices: typing.List[int]
 
     class GetDataAttr(ResponseBodyStruct):
         info: str = field(XmpStr())
@@ -1845,7 +1846,7 @@ class M_HEALTH:
         :rtype: M_HEALTH.GetDataAttr
         """
 
-        return Token(self._connection, build_get_request(self, module=self._module))
+        return Token(self._connection, build_get_request(self, module=self._module, indices=self._sub_indices))
     
 @register_command
 @dataclass

--- a/xoa_driver/internals/commands/m_commands.py
+++ b/xoa_driver/internals/commands/m_commands.py
@@ -1092,13 +1092,9 @@ class M_REVISION:
 @dataclass
 class M_VERSIONSTR:
     """
-    Returns module version number in the new format.
+    Returns module version number in the new format, e.g. "99.0.0+1.0".
 
-    For Freya, the version number of the release image, "99.0.0+1.1"
-    
-    For Odin-10G-6S-6P, the new-style version number of the image, "3.33.0+3289.1"
-
-    For everything else, the old version number is converted into the new format simply by putting the old version number into the new major number, so e.g. 327 becomes "327.0.0+0.0"
+    Obsoletes M_VERSIONNO.
     """
 
     code: typing.ClassVar[int] = 101
@@ -1109,7 +1105,7 @@ class M_VERSIONSTR:
 
     class GetDataAttr(ResponseBodyStruct):
         version_str: str = field(XmpStr())
-        """string, module version number in the new format in the following way"""
+        """string, module version number in the new format."""
 
     def get(self) -> Token[GetDataAttr]:
         """Returns module version number in the new format.

--- a/xoa_driver/internals/commands/m_commands.py
+++ b/xoa_driver/internals/commands/m_commands.py
@@ -1086,6 +1086,39 @@ class M_REVISION:
         """
 
         return Token(self._connection, build_get_request(self, module=self._module))
+    
+
+@register_command
+@dataclass
+class M_VERSIONSTR:
+    """
+    Returns module version number in the new format.
+
+    For Freya, the version number of the release image, "99.0.0+1.1"
+    
+    For Odin-10G-6S-6P, the new-style version number of the image, "3.33.0+3289.1"
+
+    For everything else, the old version number is converted into the new format simply by putting the old version number into the new major number, so e.g. 327 becomes "327.0.0+0.0"
+    """
+
+    code: typing.ClassVar[int] = 101
+    pushed: typing.ClassVar[bool] = False
+
+    _connection: 'interfaces.IConnection'
+    _module: int
+
+    class GetDataAttr(ResponseBodyStruct):
+        version_str: str = field(XmpStr())
+        """string, module version number in the new format in the following way"""
+
+    def get(self) -> Token[GetDataAttr]:
+        """Returns module version number in the new format.
+
+        :return: module version number in the new format.
+        :rtype: M_VERSIONSTR.GetDataAttr
+        """
+
+        return Token(self._connection, build_get_request(self, module=self._module))
 
 
 @register_command

--- a/xoa_driver/internals/commands/p_commands.py
+++ b/xoa_driver/internals/commands/p_commands.py
@@ -4459,6 +4459,34 @@ class P_SPEEDS_SUPPORTED:
 
 @register_command
 @dataclass
+class P_BRRSTATUS:
+    """
+    Get the actual BroadR-Reach status of the port.
+    """
+
+    code: typing.ClassVar[int] = 460
+    pushed: typing.ClassVar[bool] = True
+
+    _connection: 'interfaces.IConnection'
+    _module: int
+    _port: int
+
+    class GetDataAttr(ResponseBodyStruct):
+        mode: BRRMode = field(XmpByte())
+        """coded byte, the port’s actual BroadR-Reach mode."""
+
+    def get(self) -> Token[GetDataAttr]:
+        """Get the actual BroadR-Reach status of the port.
+
+        :return: the actual BroadR-Reach status of the port.
+        :rtype: P_BRRSTATUS.GetDataAttr
+        """
+
+        return Token(self._connection, build_get_request(self, module=self._module, port=self._port))
+    
+
+@register_command
+@dataclass
 class P_EMULATE:
     """
     The action determines if emulation functionality is enabled or disabled

--- a/xoa_driver/internals/hli_v1/modules/module_chimera.py
+++ b/xoa_driver/internals/hli_v1/modules/module_chimera.py
@@ -22,6 +22,7 @@ from xoa_driver.internals.commands import (
     M_NAME,
     M_CFPCONFIGEXT,
     M_UPGRADEPAR,
+    M_VERSIONSTR,
 )
 
 from xoa_driver.internals.hli_v1 import revisions
@@ -211,6 +212,12 @@ class ModuleChimera(bm.BaseModule["modules_state.ModuleLocalState"]):
         """Test module's model P/N name.
 
         :type: M_REVISION
+        """
+
+        self.vesion_str = M_VERSIONSTR(conn, self.module_id)
+        """Module version number in the new format
+
+        :type: M_VERSIONSTR
         """
 
         self.media = MediaModule(conn, self)

--- a/xoa_driver/internals/hli_v1/modules/module_chimera.py
+++ b/xoa_driver/internals/hli_v1/modules/module_chimera.py
@@ -214,7 +214,7 @@ class ModuleChimera(bm.BaseModule["modules_state.ModuleLocalState"]):
         :type: M_REVISION
         """
 
-        self.vesion_str = M_VERSIONSTR(conn, self.module_id)
+        self.version_str = M_VERSIONSTR(conn, self.module_id)
         """Module version number in the new format
 
         :type: M_VERSIONSTR

--- a/xoa_driver/internals/hli_v1/modules/modules_l23/family_l1.py
+++ b/xoa_driver/internals/hli_v1/modules/modules_l23/family_l1.py
@@ -28,6 +28,16 @@ class MClockSweep:
         Representation of M_CLOCKSWEEPSTATUS
         """
 
+class MHealth:
+    """Test module health"""
+    def __init__(self, conn: "itf.IConnection", module_id: int) -> None:
+        self.all = M_HEALTH(conn, module_id, [])
+        """All module health information"""
+        self.info = M_HEALTH(conn, module_id, [0])
+        """Module identification information"""
+        self.cage_insertion = M_HEALTH(conn, module_id, [1])
+        """Module cage insertion counter"""
+
 
 class ModuleFamilyL1(ModuleL23):
     """Test module Freya family"""
@@ -37,8 +47,10 @@ class ModuleFamilyL1(ModuleL23):
         self.clock_sweep = MClockSweep(conn, self.module_id)
         """Clock ppm sweep control"""
 
-        self.health = M_HEALTH(conn, self.module_id)
-        """Module health info"""
+        self.health = MHealth(conn, self.module_id)
+        """Module health information"""
+
+        
 
 
 #region Freya 1S 1P

--- a/xoa_driver/internals/hli_v1/modules/modules_l23/module_l23_base.py
+++ b/xoa_driver/internals/hli_v1/modules/modules_l23/module_l23_base.py
@@ -267,7 +267,7 @@ class ModuleL23(bm.BaseModule["modules_state.ModuleL23LocalState"]):
         :type: M_REVISION
         """
 
-        self.vesion_str = M_VERSIONSTR(conn, self.module_id)
+        self.version_str = M_VERSIONSTR(conn, self.module_id)
         """Module version number in the new format
 
         :type: M_VERSIONSTR

--- a/xoa_driver/internals/hli_v1/modules/modules_l23/module_l23_base.py
+++ b/xoa_driver/internals/hli_v1/modules/modules_l23/module_l23_base.py
@@ -28,6 +28,7 @@ from xoa_driver.internals.commands import (
     M_TXCLOCKSTATUS_NEW,
     M_TXCLOCKFILTER_NEW,
     M_UPGRADEPAR,
+    M_VERSIONSTR,
 )
 
 from xoa_driver.internals.utils import attributes as utils
@@ -264,6 +265,12 @@ class ModuleL23(bm.BaseModule["modules_state.ModuleL23LocalState"]):
         """Test module's model P/N name.
 
         :type: M_REVISION
+        """
+
+        self.vesion_str = M_VERSIONSTR(conn, self.module_id)
+        """Module version number in the new format
+
+        :type: M_VERSIONSTR
         """
 
         self.multiuser = M_MULTIUSER(conn, self.module_id)

--- a/xoa_driver/internals/hli_v1/ports/port_l23/family_m.py
+++ b/xoa_driver/internals/hli_v1/ports/port_l23/family_m.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from xoa_driver.internals.commands import P_BRRMODE
+from xoa_driver.internals.commands import P_BRRMODE, P_BRRSTATUS
 
 from .bases.port_l23_genuine import BasePortL23Genuine
 
@@ -15,6 +15,11 @@ class FamilyM(BasePortL23Genuine):
         """BRR mode.
         
         :type: P_BRRMODE
+        """
+        self.brr_status = P_BRRSTATUS(conn, module_id, port_id)
+        """Actual BRR status.
+        
+        :type: P_BRRSTATUS
         """
 
 

--- a/xoa_driver/internals/hli_v1/ports/port_l23/pcs_pma_ghijkl.py
+++ b/xoa_driver/internals/hli_v1/ports/port_l23/pcs_pma_ghijkl.py
@@ -236,18 +236,6 @@ class PRBSConfig:
         :type: PP_PRBSTYPE
         """
 
-        self.tx_type = PP_TXPRBSTYPE(conn, module_id, port_id)
-        """TX PRBS type used when in PRBS mode.
-
-        :type: PP_TXPRBSTYPE
-        """
-
-        self.rx_type = PP_RXPRBSTYPE(conn, module_id, port_id)
-        """RX PRBS type used when in PRBS mode.
-
-        :type: PP_RXPRBSTYPE
-        """
-
 
 class SDEyeDiagram:
     """L23 high-speed port SerDes eye diagram."""
@@ -347,11 +335,6 @@ class Prbs:
         """RX PRBS status on a SerDes
 
         :type: PP_RXPRBSSTATUS
-        """
-
-        self.config = PRBSConfig(conn, module_id, port_id)
-        """
-        L23 high-speed port PRBS configuration.
         """
 
 

--- a/xoa_driver/internals/hli_v1/testers/genuine/l_23/health.py
+++ b/xoa_driver/internals/hli_v1/testers/genuine/l_23/health.py
@@ -1,0 +1,16 @@
+from xoa_driver.internals.core import interfaces as itf
+from xoa_driver.internals.commands import (
+    C_HEALTH,
+)
+
+
+class Health:
+    """File uploading functions of the Valkyrie tester."""
+
+    def __init__(self, conn: "itf.IConnection") -> None:
+        self.all = C_HEALTH(conn, [])
+        """All chassis health information"""
+        self.info = C_HEALTH(conn, [0])
+        """Chassis identification information"""
+        self.uptime = C_HEALTH(conn, [1])
+        """Chassis system uptime"""

--- a/xoa_driver/internals/hli_v1/testers/l23_tester.py
+++ b/xoa_driver/internals/hli_v1/testers/l23_tester.py
@@ -20,6 +20,7 @@ from .genuine.l_23 import (
     upload_file,
     time_keeper,
     rest_api,
+    health,
 )
 if TYPE_CHECKING:
     from xoa_driver import modules
@@ -159,6 +160,13 @@ class L23Tester(BaseTester["testers_state.GenuineTesterLocalState"]):
         Identify the hostname of the PC that builds the xenaserver. It uniquely identifies the build of a xenaserver.
 
         :type: C_BUILDSTRING
+        """
+
+        self.health = health.Health(self._conn)
+        """
+        Chassis system health information.
+
+        :type: C_HEALTH
         """
 
         self.modules: TypeL23Manager = mm.ModulesManager(self._conn, get_module_type)

--- a/xoa_driver/internals/hli_v1/testers/l23_tester.py
+++ b/xoa_driver/internals/hli_v1/testers/l23_tester.py
@@ -11,6 +11,7 @@ from xoa_driver.internals.commands import (
     C_TRAFFICSYNC,
     C_VERSIONNO_MINOR,
     C_BUILDSTRING,
+    C_VERSIONSTR,
 )
 from xoa_driver.internals.utils.managers import modules_manager as mm
 from ._base_tester import BaseTester
@@ -144,6 +145,13 @@ class L23Tester(BaseTester["testers_state.GenuineTesterLocalState"]):
         Get the minor version number of the tester firmware.
 
         :type: C_VERSIONNO_MINOR
+        """
+
+        self.version_str = C_VERSIONSTR(self._conn)
+        """
+        Returns xenaserver version number in the new format.
+
+        :type: C_VERSIONSTR
         """
 
         self.build_string = C_BUILDSTRING(self._conn)

--- a/xoa_driver/internals/hli_v2/modules/modules_l23/family_l1.py
+++ b/xoa_driver/internals/hli_v2/modules/modules_l23/family_l1.py
@@ -28,6 +28,15 @@ class MClockSweep:
         Representation of M_CLOCKSWEEPSTATUS
         """
 
+class MHealth:
+    """Test module health"""
+    def __init__(self, conn: "itf.IConnection", module_id: int) -> None:
+        self.all = M_HEALTH(conn, module_id, [])
+        """All module health information"""
+        self.info = M_HEALTH(conn, module_id, [0])
+        """Module identification information"""
+        self.cage_insertion = M_HEALTH(conn, module_id, [1])
+        """Module cage insertion counter"""
 
 class ModuleFamilyL1(ModuleL23):
     """Test module Freya family"""
@@ -37,8 +46,8 @@ class ModuleFamilyL1(ModuleL23):
         self.clock_sweep = MClockSweep(conn, self.module_id)
         """Clock ppm sweep control"""
 
-        self.health = M_HEALTH(conn, self.module_id)
-        """Module health info"""
+        self.health = MHealth(conn, self.module_id)
+        """Module health information"""
 
 
 #region Freya 1S 1P

--- a/xoa_driver/internals/hli_v2/modules/modules_l23/module_l23_base.py
+++ b/xoa_driver/internals/hli_v2/modules/modules_l23/module_l23_base.py
@@ -242,7 +242,7 @@ class ModuleL23(bm.BaseModule["modules_state.ModuleL23LocalState"]):
         Representation of M_REVISION
         """
 
-        self.vesion_str = M_VERSIONSTR(conn, self.module_id)
+        self.version_str = M_VERSIONSTR(conn, self.module_id)
         """Module version number in the new format
 
         :type: M_VERSIONSTR

--- a/xoa_driver/internals/hli_v2/modules/modules_l23/module_l23_base.py
+++ b/xoa_driver/internals/hli_v2/modules/modules_l23/module_l23_base.py
@@ -28,6 +28,7 @@ from xoa_driver.internals.commands import (
     M_TXCLOCKSTATUS_NEW,
     M_TXCLOCKFILTER_NEW,
     M_UPGRADEPAR,
+    M_VERSIONSTR,
 )
 
 from xoa_driver.internals.utils import attributes as utils
@@ -239,6 +240,12 @@ class ModuleL23(bm.BaseModule["modules_state.ModuleL23LocalState"]):
         self.revision = M_REVISION(conn, self.module_id)
         """Test module's model P/N name.
         Representation of M_REVISION
+        """
+
+        self.vesion_str = M_VERSIONSTR(conn, self.module_id)
+        """Module version number in the new format
+
+        :type: M_VERSIONSTR
         """
 
         self.multiuser = M_MULTIUSER(conn, self.module_id)

--- a/xoa_driver/internals/hli_v2/ports/port_l23/family_m.py
+++ b/xoa_driver/internals/hli_v2/ports/port_l23/family_m.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from xoa_driver.internals.commands import P_BRRMODE
+from xoa_driver.internals.commands import P_BRRMODE, P_BRRSTATUS
 
 from .bases.port_l23_genuine import BasePortL23Genuine
 
@@ -14,6 +14,11 @@ class FamilyM(BasePortL23Genuine):
         self.brr_mode = P_BRRMODE(conn, module_id, port_id)
         """BRR mode.
         Representation of P_BRRMODE
+        """
+        self.brr_status = P_BRRSTATUS(conn, module_id, port_id)
+        """Actual BRR status.
+        
+        :type: P_BRRSTATUS
         """
 
 

--- a/xoa_driver/internals/hli_v2/ports/port_l23/pcs_pma_ghijkl.py
+++ b/xoa_driver/internals/hli_v2/ports/port_l23/pcs_pma_ghijkl.py
@@ -203,16 +203,6 @@ class PRBSConfig:
         Representation of PP_PRBSTYPE
         """
 
-        self.tx_type = PP_TXPRBSTYPE(conn, module_id, port_id)
-        """TX PRBS type used when in PRBS mode.
-        Representation of PP_TXPRBSTYPE
-        """
-
-        self.rx_type = PP_RXPRBSTYPE(conn, module_id, port_id)
-        """RX PRBS type used when in PRBS mode.
-        Representation of PP_RXPRBSTYPE
-        """
-
 
 class SDEyeDiagram:
     """L23 high-speed port SerDes eye diagram."""
@@ -325,11 +315,6 @@ class Prbs:
         self.status = PP_RXPRBSSTATUS(conn, module_id, port_id, serdes_xindex)
         """RX PRBS status on a SerDes
         Representation of PP_RXPRBSSTATUS
-        """
-
-        self.config = PRBSConfig(conn, module_id, port_id)
-        """
-        L23 high-speed port PRBS configuration.
         """
 
 

--- a/xoa_driver/internals/hli_v2/testers/genuine/l_23/health.py
+++ b/xoa_driver/internals/hli_v2/testers/genuine/l_23/health.py
@@ -1,0 +1,16 @@
+from xoa_driver.internals.core import interfaces as itf
+from xoa_driver.internals.commands import (
+    C_HEALTH,
+)
+
+
+class Health:
+    """File uploading functions of the Valkyrie tester."""
+
+    def __init__(self, conn: "itf.IConnection") -> None:
+        self.all = C_HEALTH(conn, [])
+        """All chassis health information"""
+        self.info = C_HEALTH(conn, [0])
+        """Chassis identification information"""
+        self.uptime = C_HEALTH(conn, [1])
+        """Chassis system uptime"""

--- a/xoa_driver/internals/hli_v2/testers/l23_tester.py
+++ b/xoa_driver/internals/hli_v2/testers/l23_tester.py
@@ -11,6 +11,7 @@ from xoa_driver.internals.commands import (
     C_TRAFFICSYNC,
     C_VERSIONNO_MINOR,
     C_BUILDSTRING,
+    C_VERSIONSTR,
 )
 from xoa_driver.internals.core.transporter.logger import CustomLogger
 from xoa_driver.internals.utils.managers.modules_manager import ModulesManager
@@ -120,6 +121,12 @@ class L23Tester(BaseTester["testers_state.GenuineTesterLocalState"]):
         self.version_no_minor = C_VERSIONNO_MINOR(self._conn)
         """
         Representation of C_VERSIONNO_MINOR
+        """
+        self.version_str = C_VERSIONSTR(self._conn)
+        """
+        Returns xenaserver version number in the new format.
+
+        :type: C_VERSIONSTR
         """
         self.build_string = C_BUILDSTRING(self._conn)
         """

--- a/xoa_driver/internals/hli_v2/testers/l23_tester.py
+++ b/xoa_driver/internals/hli_v2/testers/l23_tester.py
@@ -21,6 +21,7 @@ from .genuine.l_23 import (
     upload_file,
     time_keeper,
     rest_api,
+    health,
 )
 if TYPE_CHECKING:
     from xoa_driver.v2 import modules
@@ -131,6 +132,12 @@ class L23Tester(BaseTester["testers_state.GenuineTesterLocalState"]):
         self.build_string = C_BUILDSTRING(self._conn)
         """
         Representation of C_BUILDSTRING
+        """
+        self.health = health.Health(self._conn)
+        """
+        Chassis system health information.
+
+        :type: C_HEALTH
         """
         self.modules: TypeL23Manager = ModulesManager(self._conn, get_module_type)
         """

--- a/xoa_driver/internals/utils/managers/modules_manager.py
+++ b/xoa_driver/internals/utils/managers/modules_manager.py
@@ -18,7 +18,8 @@ if TYPE_CHECKING:
     from xoa_driver.internals.core import interfaces as itf
 from xoa_driver.internals.commands import (
     M_REVISION,
-    M_MODEL
+    M_MODEL,
+    M_VERSIONSTR,
 )
 from .abc import AbcResourcesManager
 from .exceptions import (


### PR DESCRIPTION
* [Add c_versionstr and m_versionstr](https://github.com/xenanetworks/open-automation-python-api/commit/018ef64f194fc457a75c17e4ee835752b6e05db0)
* [Add tester.health and module.health](https://github.com/xenanetworks/open-automation-python-api/commit/d27cb1a4ddf5bdbfe13d1abbbc66185e76c6455e)
* [Add BRR Status api](https://github.com/xenanetworks/open-automation-python-api/commit/537dc55e5d0f0c5ca43520fab7e7228561d7bd89)
* [Remove await port.serdes[0].prbs.config](https://github.com/xenanetworks/open-automation-python-api/commit/3da627459b8e17c971ccfc0232ec4ffb47554ce0)